### PR TITLE
Add missing import for QMessageBox

### DIFF
--- a/Discovery/config_dialog.py
+++ b/Discovery/config_dialog.py
@@ -14,7 +14,7 @@ import os
 
 from PyQt5.QtCore import QSettings, Qt, QUrl
 from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QApplication, QDialogButtonBox
+from PyQt5.QtWidgets import QApplication, QDialogButtonBox, QMessageBox
 from PyQt5 import uic
 
 from . import dbutils


### PR DESCRIPTION
This PR is to fix the fact that I was getting and issue when I wanted to remove a connexion in the configuration e.g 
![selection_852](https://user-images.githubusercontent.com/642120/39259649-3f69dd76-48b7-11e8-904f-aa9e40056f80.png)

As stated `QMessageBox` is required at https://github.com/lutraconsulting/qgis-discovery-plugin/blob/master/Discovery/config_dialog.py#L324 but was not imported