### PR TITLE
migrate to QgsSettings to use global settings file

### DIFF
--- a/Discovery/config_dialog.py
+++ b/Discovery/config_dialog.py
@@ -21,6 +21,8 @@ from . import discoveryplugin
 from . import gpkg_utils
 from . import mssql_utils
 
+from qgis.core import QgsSettings
+
 plugin_dir = os.path.dirname(__file__)
 
 uiConfigDialog, qtBaseClass = uic.loadUiType(os.path.join(plugin_dir, 'config_dialog.ui'))
@@ -47,7 +49,7 @@ class ConfigDialog(qtBaseClass, uiConfigDialog):
         self.cboSchema.currentIndexChanged.connect(self.populate_tables)
         self.cboTable.currentIndexChanged.connect(self.populate_columns)
 
-        settings = QSettings()
+        settings = QgsSettings()
         settings.beginGroup("/Discovery")
 
         # init config list

--- a/Discovery/dbutils.py
+++ b/Discovery/dbutils.py
@@ -14,7 +14,7 @@ from PyQt5.QtCore import QSettings
 
 import psycopg2
 
-from qgis.core import QgsApplication, QgsAuthMethodConfig
+from qgis.core import QgsApplication, QgsAuthMethodConfig, QgsSettings
 
 
 def get_connection(conn_info):
@@ -27,24 +27,24 @@ def get_connection(conn_info):
 
 
 def get_postgres_connections():
-    """ Read PostgreSQL connection names from QSettings stored by QGIS
+    """ Read PostgreSQL connection names from QgsSettings stored by QGIS
     """
-    settings = QSettings()
+    settings = QgsSettings()
     settings.beginGroup(u"/PostgreSQL/connections/")
     return settings.childGroups()
 
 
 """
 def current_postgres_connection():
-    settings = QSettings()
+    settings = QgsSettings()
     settings.beginGroup("/Discovery")
     return settings.value("connection", "", type=str)
 """
 
 def get_postgres_conn_info(selected):
-    """ Read PostgreSQL connection details from QSettings stored by QGIS
+    """ Read PostgreSQL connection details from QgsSettings stored by QGIS
     """
-    settings = QSettings()
+    settings = QgsSettings()
     settings.beginGroup(u"/PostgreSQL/connections/" + selected)
     if not settings.contains("database"): # non-existent entry?
         return {}

--- a/Discovery/discoveryplugin.py
+++ b/Discovery/discoveryplugin.py
@@ -33,7 +33,8 @@ from qgis.core import (
     QgsGeometry,
     QgsRectangle,
     QgsVectorLayer,
-    QgsWkbTypes
+    QgsWkbTypes,
+    QgsSettings
 )
 from qgis.gui import QgsVertexMarker, QgsFilterLineEdit, QgsRubberBand
 from qgis.utils import iface
@@ -168,7 +169,7 @@ class DiscoveryPlugin:
 
         # Add combobox for configs
         self.config_combo = QComboBox()
-        settings = QSettings()
+        settings = QgsSettings()
         settings.beginGroup("/Discovery")
         config_list = settings.value("config_list")
 
@@ -436,7 +437,7 @@ class DiscoveryPlugin:
         # the following code reads the configuration file which setups the plugin to search in the correct database,
         # table and method
 
-        settings = QSettings()
+        settings = QgsSettings()
         settings.beginGroup("/Discovery")
 
         connection = settings.value(key + "connection", "", type=str)

--- a/Discovery/mssql_utils.py
+++ b/Discovery/mssql_utils.py
@@ -1,14 +1,14 @@
 import sys
 from PyQt5.QtCore import QSettings
 from PyQt5.QtSql import QSqlDatabase, QSqlQuery
-from qgis.core import QgsMessageLog
+from qgis.core import QgsMessageLog, QgsSettings
 from . import dbutils
 
 
 def get_mssql_connections():
-    """ Read PostgreSQL connection names from QSettings stored by QGIS
+    """ Read PostgreSQL connection names from QgsSettings stored by QGIS
     """
-    settings = QSettings()
+    settings = QgsSettings()
     settings.beginGroup(u"/MSSQL/connections/")
     return settings.childGroups()
 
@@ -52,7 +52,7 @@ def get_connection(conn_name, service, host, database, username, password):
 
 
 def get_mssql_conn(connection):
-    settings = QSettings()
+    settings = QgsSettings()
     settings.beginGroup(u"/MSSQL/connections/" + connection)
     service = settings.value('/service', "")
     host = settings.value('/host', "")


### PR DESCRIPTION
A successor for QSettings (throughout the QGIS codebase) seems to be QgsSettings (#72), which enables the (additional) use of a global settings file. 
Therefore I added `from qgis.core import QgsSettings` to config_dialog.py, dbutils.py, discoveryplugin.py & mssql_utils.py and replaced every occurence of QSettings in these files.