### PR TITLE
Resolve two warnings

### DIFF
--- a/Discovery/config_dialog.py
+++ b/Discovery/config_dialog.py
@@ -197,7 +197,7 @@ class ConfigDialog(qtBaseClass, uiConfigDialog):
         h_color.setNamedColor(settings.value(key + "highlight_color", "#FF0000", type=str))
         self.color_picker.setColor(h_color)
         self.chkMarkerTime.setChecked(settings.value("marker_time_enabled", True, type=bool))
-        self.spinMarkerTime.setValue(settings.value("marker_time", 5000, type=int) / 1000)
+        self.spinMarkerTime.setValue(settings.value("marker_time", 5000, type=int) // 1000)
         self.chkBarInfoTime.setChecked(settings.value("bar_info_time_enabled", True, type=bool))
         self.spinBarInfoTime.setValue(settings.value("bar_info_time", 30, type=int))
         self.spinLimitResults.setValue(settings.value(key + "limit_results", 1000, type=int))

--- a/Discovery/discoveryplugin.py
+++ b/Discovery/discoveryplugin.py
@@ -380,7 +380,7 @@ class DiscoveryPlugin:
         location_geom = QgsGeometry.fromWkt(geometry_text)
         canvas = self.iface.mapCanvas()
         dst_srid = canvas.mapSettings().destinationCrs().authid()
-        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem(src_epsg),
+        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem.fromEpsgId(src_epsg),
                                            QgsCoordinateReferenceSystem(dst_srid),
                                            canvas.mapSettings().transformContext())
         # Ensure the geometry from the DB is reprojected to the same SRID as the map canvas


### PR DESCRIPTION
This pull request fixes two warnings that appear in the Log window when using this plugin on QGIS 3.28.

One is a Deprecation Warning when using a QgsCoordinateReferenceSystem constructor.

The other changes a division operator to an floor division operator.