### PR TITLE
Fix locator filter (fix #84)

### DIFF
--- a/Discovery/locator_filter.py
+++ b/Discovery/locator_filter.py
@@ -11,7 +11,7 @@
 # (at your option) any later version.
 
 
-from qgis.core import QgsLocatorFilter, QgsLocatorResult
+from qgis.core import QgsMessageLog, QgsLocatorFilter, QgsLocatorResult
 
 from . import config_dialog
 from . import dbutils
@@ -53,6 +53,9 @@ class DiscoveryLocatorFilter(QgsLocatorFilter):
         )
 
         cur = self.plugin.get_db()
+        if not cur:
+            QgsMessageLog.logMessage("The Locator Bar filter is currently only supported on PostGIS", "Discovery")
+            return
         cur.execute(query_text, query_dict)
 
         for row in cur.fetchall():

--- a/Discovery/locator_filter.py
+++ b/Discovery/locator_filter.py
@@ -48,7 +48,9 @@ class DiscoveryLocatorFilter(QgsLocatorFilter):
                                     self.plugin.extra_expr_columns,
                                     self.plugin.postgisschema,
                                     self.plugin.postgistable,
-                                    self.plugin.escapespecchars)
+                                    self.plugin.escapespecchars,
+                                    self.plugin.limit_results,
+        )
 
         cur = self.plugin.get_db()
         cur.execute(query_text, query_dict)


### PR DESCRIPTION
In d6cd2b39 a new limit parameter was introduced but not added to the locator bar filter code. I added it to the call in the locator bar. While I did not thoroughly test this but think it is consistent.

I also added a short warning message if the user tries to use the locator bar with anything not-PostgreSQL. I assume this is correct because the used `dbutils.get_search_sql()` function is only used in a PostgreSQL context in the plugin.

Fixes #84 