### PR TITLE
Don't abort search on GeoPackages (fix #95)

### DIFF
--- a/Discovery/discoveryplugin.py
+++ b/Discovery/discoveryplugin.py
@@ -329,8 +329,9 @@ class DiscoveryPlugin:
 
     def perform_search(self):
         db = self.get_db()
-        if db is None:
+        if db is None and self.data_type != "gpkg":
             return
+
         self.search_results = []
         suggestions = []
         if self.data_type == "postgres":


### PR DESCRIPTION
https://github.com/lutraconsulting/qgis-discovery-plugin/commit/25f92172f84518c69a21c8044472844684bef87b broke searching in GeoPackages

I added a quick and dirty(?) fix so that PostgreSQL/MSSQL specific code does not ruin it for GeoPackage users.

Fixes #95