### PR TITLE
Get only "SRID" CRS identifier (not authority+identifier) for GeoPackage layers

### DIFF
--- a/Discovery/gpkg_utils.py
+++ b/Discovery/gpkg_utils.py
@@ -1,5 +1,5 @@
 from osgeo import ogr, gdal
-from qgis.core import QgsVectorLayer, QgsDataSourceUri, QgsFeatureRequest, QgsExpression
+from qgis.core import QgsVectorLayer, QgsDataSourceUri, QgsFeatureRequest, QgsExpression, QgsMessageLog
 from .utils import is_number
 
 
@@ -50,7 +50,15 @@ def search_gpkg(search_text, search_field, echo_search_column, display_fields, e
     for f in it:
         feature_info = []
         geom = f.geometry().asWkt()
-        epsg = int(layer.crs().authid().lstrip("EPSG:"))  # only the plain integer code is wanted later on
+
+        crs_auth_id = layer.crs().authid()
+        try:
+            # only the plain integer code is wanted later on
+            epsg = int(crs_auth_id.lstrip("EPSG:"))
+        except ValueError:
+            QgsMessageLog.logMessage(f"{crs_auth_id} is not an EPSG code.", "Discovery")
+            return []
+
         feature_info.append(geom)
         feature_info.append(epsg)
         available_fields = [field.name() for field in f.fields()]

--- a/Discovery/gpkg_utils.py
+++ b/Discovery/gpkg_utils.py
@@ -50,7 +50,7 @@ def search_gpkg(search_text, search_field, echo_search_column, display_fields, e
     for f in it:
         feature_info = []
         geom = f.geometry().asWkt()
-        epsg = layer.crs().authid()
+        epsg = int(layer.crs().authid().lstrip("EPSG:"))  # only the plain integer code is wanted later on
         feature_info.append(geom)
         feature_info.append(epsg)
         available_fields = [field.name() for field in f.fields()]
@@ -70,4 +70,3 @@ def search_gpkg(search_text, search_field, echo_search_column, display_fields, e
                 feature_info.append("")
         result.append(feature_info)
     return result
-


### PR DESCRIPTION
While for PostgreSQL/PostGIS and MSSQL [ST_SRID](https://postgis.net/docs/ST_SRID.html) resp. [STSrid](https://learn.microsoft.com/de-de/sql/t-sql/spatial-geometry/stsrid-geometry-data-type?view=sql-server-ver16) are used to get a simple integer EPSG code:

https://github.com/lutraconsulting/qgis-discovery-plugin/blob/f652251b2476fecc839eadde9be1aaaf2a8680a6/Discovery/mssql_utils.py#L113

https://github.com/lutraconsulting/qgis-discovery-plugin/blob/f652251b2476fecc839eadde9be1aaaf2a8680a6/Discovery/dbutils.py#L179

For GeoPackage the layer's CRS's `authid()` is used, which is a full string with authority identifier and code (e.g. "EPSG:4326"):

https://github.com/lutraconsulting/qgis-discovery-plugin/blob/f652251b2476fecc839eadde9be1aaaf2a8680a6/Discovery/gpkg_utils.py#L53

This breaks the transformation in `select_result()` as [`QgsCoordinateReferenceSystem.fromEpsgId(foo)`](https://qgis.org/pyqgis/master/core/QgsCoordinateReferenceSystem.html#qgis.core.QgsCoordinateReferenceSystem.fromEpsgId) is used, which takes only the integer identifier.

https://github.com/lutraconsulting/qgis-discovery-plugin/blob/f652251b2476fecc839eadde9be1aaaf2a8680a6/Discovery/discoveryplugin.py#L383

This PR simply strips "EPSG:" from the GeoPackage's auth ID. This won't work with non-EPSG CRSses but then I am not sure what would happen in PostGIS/MSSQL in those cases. It's an improvement for sure as it makes things work again.

Fixes follow-up comments in #95